### PR TITLE
change "Tube Archivist IP" to "Tube Archivist URL"

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -16,7 +16,7 @@ function getBrowser() {
             return chrome;
         }
     } else {
-        console.log("failed to dedect browser");
+        console.log("failed to detect browser");
         throw "browser detection error"
     };
 }

--- a/extension/index.html
+++ b/extension/index.html
@@ -18,7 +18,7 @@
         </div>
         <hr>
         <form class="login-form">
-            <label for="url">Tube Archivist IP:</label>
+            <label for="url">Tube Archivist URL:</label>
             <input type="text" id="url" name="url">
             <label for="port">Tube Archivist Port:</label>
             <input type="text" id="port" name="port">

--- a/extension/index.html
+++ b/extension/index.html
@@ -18,10 +18,8 @@
         </div>
         <hr>
         <form class="login-form">
-            <label for="url">Tube Archivist URL:</label>
-            <input type="text" id="url" name="url">
-            <label for="port">Tube Archivist Port:</label>
-            <input type="text" id="port" name="port">
+            <label for="full-url">Tube Archivist URL:</label>
+            <input type="text" id="full-url" name="url">
             <label for="api-key">Tube Archivist API Key:</label>
             <input type="password" id="api-key" name="api-key">
         </form>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -28,8 +28,8 @@ document.getElementById("save-login").addEventListener("click", function () {
     let parsed = new URL(url);
     let toStore = {
         "access": {
-            "url": parsed.host,
-            "port": parsed.port || '80',
+            "url": `${parsed.protocol}//${parsed.hostname}`,
+            "port": parsed.port || (parsed.protocol === 'https' ? '443' : '80'),
             "apiKey": document.getElementById("api-key").value
         }
     };

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -21,15 +21,15 @@ function getBrowser() {
 
 // store access details
 document.getElementById("save-login").addEventListener("click", function () {
-    let url = document.getElementById("url").value;
+    let url = document.getElementById("full-url").value;
     if (!url.includes('://')) {
         url = 'http://' + url;
     }
     let parsed = new URL(url);
     let toStore = {
         "access": {
-            "url": document.getElementById("full-url").host,
-            "port": document.getElementById("port").port || '80',
+            "url": parsed.host,
+            "port": parsed.port || '80',
             "apiKey": document.getElementById("api-key").value
         }
     };
@@ -91,7 +91,7 @@ function pingBackend() {
             console.log("connection validated")
         }
     }
-    
+
     function handleError(error) {
         console.log(`Error: ${error}`);
         setStatusIcon(false);
@@ -175,7 +175,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         setCookieState();
 
     }
-    
+
     function onError(error) {
         console.log(`Error: ${error}`);
     };

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -21,10 +21,15 @@ function getBrowser() {
 
 // store access details
 document.getElementById("save-login").addEventListener("click", function () {
+    let url = document.getElementById("url").value;
+    if (!url.includes('://')) {
+        url = 'http://' + url;
+    }
+    let parsed = new URL(url);
     let toStore = {
         "access": {
-            "url": document.getElementById("url").value,
-            "port": document.getElementById("port").value,
+            "url": document.getElementById("full-url").host,
+            "port": document.getElementById("port").port || '80',
             "apiKey": document.getElementById("api-key").value
         }
     };
@@ -150,8 +155,12 @@ document.addEventListener("DOMContentLoaded", async () => {
             setStatusIcon(false);
             return
         }
-        document.getElementById("url").value = item.access.url;
-        document.getElementById("port").value = item.access.port;
+        let { url, port } = item.access;
+        let fullUrl = url;
+        if (!(url.startsWith('http://') && port === '80')) {
+            fullUrl += `:${port}`;
+        }
+        document.getElementById("full-url").value = fullUrl;
         document.getElementById("api-key").value = item.access.apiKey;
         pingBackend();
         addUrl(item.access);


### PR DESCRIPTION
Saying "IP" is confusing when a.) it can be a domain name, not an IP and b.) it's supposed to include the HTTP part, not just a bare IP. (It's also documented as "URL" in the readme.)

Honestly it's a bit weird to have the protocol and domain in one place and the port in a different field. Is there a reason not to just have one field that expects something like `http://tubearchivist.local:8000`, i.e. a full URL as you'd have in the browser? I can make that change instead if you'd prefer.