### PR TITLE
fix port parsing logic

### DIFF
--- a/extension/popup.js
+++ b/extension/popup.js
@@ -29,7 +29,7 @@ document.getElementById("save-login").addEventListener("click", function () {
     let toStore = {
         "access": {
             "url": `${parsed.protocol}//${parsed.hostname}`,
-            "port": parsed.port || (parsed.protocol === 'https' ? '443' : '80'),
+            "port": parsed.port || (parsed.protocol === 'https:' ? '443' : '80'),
             "apiKey": document.getElementById("api-key").value
         }
     };


### PR DESCRIPTION
```js
let url = new URL('https://example.com:443');
console.log(url.port); // empty string, because it's the default for the protocol
console.log(url.protocol); // 'https:' - note the colon, which was missing in the logic below
```