### PR TITLE
Refactor message passing and surface errors to users

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -210,7 +210,15 @@ function handleMessage(request, sender, sendResponse) {
     }
   })()
     .then(value => sendResponse({ success: true, value }))
-    .catch(e => sendResponse({ success: false, value: e.message }));
+    .catch(e => {
+      console.error(e);
+      let message = e?.message ?? e;
+      if (message === 'Failed to fetch') {
+        // chrome's error message for failed `fetch` is not very user-friendly
+        message = 'Could not connect to server';
+      }
+      sendResponse({ success: false, value: message });
+    });
   return true;
 }
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -87,10 +87,16 @@ async function getCookieState() {
 // send ping to server, return response
 async function verifyConnection() {
   const path = 'api/ping/';
-  let response = await sendGet(path);
-  console.log('verify connection: ' + JSON.stringify(response));
+  let message = await sendGet(path);
+  console.log('verify connection: ' + JSON.stringify(message));
 
-  return response;
+  if (message?.response === 'pong') {
+    return true;
+  } else if (message?.detail) {
+    throw new Error(message.detail);
+  } else {
+    throw new Error(`got unknown message ${JSON.stringify(message)}`);
+  }
 }
 
 // send youtube link from injected buttons

--- a/extension/index.html
+++ b/extension/index.html
@@ -26,6 +26,7 @@
         <div class="submit">
             <button id="save-login">Save</button><span id="status-icon">&#9744;</span>
         </div>
+        <div id="error-out"></div>
         <hr>
         <p>Options:</p>
         <div class="options">

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -15,9 +15,17 @@ function getBrowser() {
       return chrome;
     }
   } else {
-    console.log('failed to dedect browser');
+    console.log('failed to detect browser');
     throw 'browser detection error';
   }
+}
+
+async function sendMessage(message) {
+  let { success, value } = await browserType.runtime.sendMessage(message);
+  if (!success) {
+    throw value;
+  }
+  return value;
 }
 
 // store access details
@@ -75,7 +83,7 @@ function sendCookie() {
   if (checked === false) {
     return;
   }
-  let sending = browserType.runtime.sendMessage({ sendCookie: true });
+  let sending = sendMessage({ type: 'sendCookie' });
   sending.then(handleResponse, handleError);
 }
 
@@ -89,12 +97,12 @@ function pingBackend() {
   }
 
   function handleError(error) {
-    console.log(`Error: ${error}`);
+    console.log(`Verify got error: ${error}`);
     setStatusIcon(false);
   }
 
   console.log('ping TA server');
-  let sending = browserType.runtime.sendMessage({ verify: true });
+  let sending = sendMessage({ type: 'verify' });
   sending.then(handleResponse, handleError);
 }
 
@@ -118,7 +126,7 @@ function setCookieState() {
   }
 
   console.log('set cookie state');
-  let sending = browserType.runtime.sendMessage({ cookieState: true });
+  let sending = sendMessage({ type: 'cookieState' });
   sending.then(handleResponse, handleError);
   document.getElementById('sendCookies').checked = true;
 }

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -28,6 +28,16 @@ async function sendMessage(message) {
   return value;
 }
 
+let errorOut = document.getElementById('error-out');
+function setError(message) {
+  errorOut.style.display = 'initial';
+  errorOut.innerText = message;
+}
+
+function clearError() {
+  errorOut.style.display = 'none';
+}
+
 // store access details
 document.getElementById('save-login').addEventListener('click', function () {
   let url = document.getElementById('full-url').value;
@@ -60,6 +70,7 @@ document.getElementById('sendCookies').addEventListener('click', function () {
 
 function sendCookie() {
   console.log('popup send cookie');
+  clearError();
 
   function handleResponse(message) {
     console.log('handle cookie response: ' + JSON.stringify(message));
@@ -69,6 +80,7 @@ function sendCookie() {
 
   function handleError(error) {
     console.log(`Error: ${error}`);
+    setError(error);
   }
 
   let checked = document.getElementById('sendCookies').checked;
@@ -89,16 +101,23 @@ function sendCookie() {
 
 // send ping message to TA backend
 function pingBackend() {
+  clearError();
   function handleResponse(message) {
-    if (message.response === 'pong') {
+    // TODO move this check into background.js
+    if (message?.response === 'pong') {
       setStatusIcon(true);
       console.log('connection validated');
+    } else if (message?.detail) {
+      handleError(message.detail);
+    } else {
+      handleError(`got unknown message ${JSON.stringify(message)}`);
     }
   }
 
   function handleError(error) {
     console.log(`Verify got error: ${error}`);
     setStatusIcon(false);
+    setError(error);
   }
 
   console.log('ping TA server');
@@ -113,6 +132,7 @@ function addUrl(access) {
 }
 
 function setCookieState() {
+  clearError();
   function handleResponse(message) {
     console.log(message);
     document.getElementById('sendCookies').checked = message.cookie_enabled;
@@ -123,6 +143,7 @@ function setCookieState() {
 
   function handleError(error) {
     console.log(`Error: ${error}`);
+    setError(error);
   }
 
   console.log('set cookie state');

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -44,18 +44,23 @@ document.getElementById('save-login').addEventListener('click', function () {
   if (!url.includes('://')) {
     url = 'http://' + url;
   }
-  let parsed = new URL(url);
-  let toStore = {
-    access: {
-      url: `${parsed.protocol}//${parsed.hostname}`,
-      port: parsed.port || (parsed.protocol === 'https:' ? '443' : '80'),
-      apiKey: document.getElementById('api-key').value,
-    },
-  };
-  browserType.storage.local.set(toStore, function () {
-    console.log('Stored connection details: ' + JSON.stringify(toStore));
-    pingBackend();
-  });
+  try {
+    clearError();
+    let parsed = new URL(url);
+    let toStore = {
+      access: {
+        url: `${parsed.protocol}//${parsed.hostname}`,
+        port: parsed.port || (parsed.protocol === 'https:' ? '443' : '80'),
+        apiKey: document.getElementById('api-key').value,
+      },
+    };
+    browserType.storage.local.set(toStore, function () {
+      console.log('Stored connection details: ' + JSON.stringify(toStore));
+      pingBackend();
+    });
+  } catch (e) {
+    setError(e.message);
+  }
 });
 
 // verify connection status

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -102,7 +102,7 @@ function sendCookie() {
 // send ping message to TA backend
 function pingBackend() {
   clearError();
-  function handleResponse(message) {
+  function handleResponse() {
     console.log('connection validated');
     setStatusIcon(true);
   }

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -103,15 +103,8 @@ function sendCookie() {
 function pingBackend() {
   clearError();
   function handleResponse(message) {
-    // TODO move this check into background.js
-    if (message?.response === 'pong') {
-      setStatusIcon(true);
-      console.log('connection validated');
-    } else if (message?.detail) {
-      handleError(message.detail);
-    } else {
-      handleError(`got unknown message ${JSON.stringify(message)}`);
-    }
+    console.log('connection validated');
+    setStatusIcon(true);
   }
 
   function handleError(error) {

--- a/extension/script.js
+++ b/extension/script.js
@@ -22,6 +22,14 @@ function getBrowser() {
   }
 }
 
+async function sendMessage(message) {
+  let { success, value } = await browserType.runtime.sendMessage(message);
+  if (!success) {
+    throw value;
+  }
+  return value;
+}
+
 const downloadIcon = `<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 viewBox="0 0 500 500" style="enable-background:new 0 0 500 500;" xml:space="preserve">
 <style type="text/css">
@@ -362,18 +370,14 @@ function sendUrl(url, action, button) {
   function handleError(error) {
     console.log('error');
     console.log(JSON.stringify(error));
+    buttonError(button);
   }
 
-  let payload = {
-    youtube: {
-      url: url,
-      action: action,
-    },
-  };
+  let message = { type: 'youtube', action, url };
 
-  console.log('youtube link: ' + JSON.stringify(payload));
+  console.log('youtube link: ' + JSON.stringify(message));
 
-  let sending = browserType.runtime.sendMessage(payload);
+  let sending = sendMessage(message);
   sending.then(handleResponse, handleError);
 }
 

--- a/extension/script.js
+++ b/extension/script.js
@@ -373,7 +373,7 @@ function sendUrl(url, action, button) {
     buttonError(button);
   }
 
-  let message = { type: 'youtube', action, url };
+  let message = { type: action, url };
 
   console.log('youtube link: ' + JSON.stringify(message));
 

--- a/extension/style.css
+++ b/extension/style.css
@@ -77,3 +77,7 @@ hr {
 .icons img {
     width: 25px;
 }
+#error-out {
+    color: red;
+    display: none; /* will be made visible when an error occurs */
+}


### PR DESCRIPTION
This cleans up the logic for passing messages between `popup.js`/`script.js` and `background.js`, so that instead of determining the kind of message based on which properties the message object has, there is an explicit `type` property. This is more traditional and, in my experience, _much_ easier to maintain and reason about. Plus it means that if you get a message you don't recognize it's easy to throw an appropriate error.

Also, it wraps up the message-passing logic so that errors in `background.js` propagate to the script which passed the message, and surfaces those errors in the popup. (Previously errors [weren't being handled at all](https://github.com/tubearchivist/browser-extension/blob/c7069d90cbd6ebf679190d8a322a6808f5516f26/extension/background.js#L181); in Firefox that would eventually trigger an error in the popup, when the `sendMessage` handler was garbage collected, but in Chrome that failure was completely silent.)

<img width="371" alt="Screenshot 2023-02-11 at 5 03 48 PM" src="https://user-images.githubusercontent.com/1653598/218287660-1982b210-532e-4958-be95-f06023db8ed0.png">
<img width="371" alt="Screenshot 2023-02-11 at 5 04 08 PM" src="https://user-images.githubusercontent.com/1653598/218287661-260f0597-6e2f-463f-b378-3cd620e4394b.png">
