### PR TITLE
Show checkmark for already downloaded currently playing videos

### DIFF
--- a/extension/script.js
+++ b/extension/script.js
@@ -437,11 +437,13 @@ function checkVideoExists(taButton) {
     console.error(e);
   }
 
-  if (!taButton.parentElement) return;
-  let videoId = getVideoId(taButton.parentElement);
-  taButton.setAttribute('data-id', videoId);
-  taButton.setAttribute('data-type', 'video');
-  taButton.title = `TA download video: ${taButton.parentElement.innerText} [${videoId}]`;
+  let videoId = taButton.dataset.id;
+  if (taButton.parentElement) {
+    videoId = getVideoId(taButton.parentElement);
+    taButton.setAttribute('data-id', videoId);
+    taButton.setAttribute('data-type', 'video');
+    taButton.title = `TA download video: ${taButton.parentElement.innerText} [${videoId}]`;
+  }
 
   let message = { type: 'videoExists', videoId };
   let sending = sendMessage(message);


### PR DESCRIPTION
Looks like this was regressed from v0.2.1 to v0.2.2 in this commit sha: f8d69f58830e178b3eb34e386e6adaee6298ec3f

Already downloaded video currently playing in YouTube were still showing the download icon instead of checkmark icon in TA.

This commit should fix this (as in ss).
![would_you_be_so_kind](https://github.com/tubearchivist/browser-extension/assets/20314742/9b2559bc-753d-422d-949d-5e0ac87bb26c)
