### PR TITLE
Fix handling of cookies for absolute domains

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -195,9 +195,12 @@ async function cookieStr(cookieLines) {
 }
 
 function buildCookieLine(cookie) {
+  // 2nd argument controls subdomains, and must match leading dot in domain
+  let includeSubdomains = cookie.domain.startsWith('.') ? 'TRUE' : 'FALSE';
+
   return [
     cookie.domain,
-    'TRUE',
+    includeSubdomains,
     cookie.path,
     cookie.httpOnly.toString().toUpperCase(),
     Math.trunc(cookie.expirationDate) || 0,


### PR DESCRIPTION
As mentioned in #42, other extensions might introduce additional cookies into the `youtube.com` cookie space. There appears to be a difference between cookies which are readable from subdomains and cookies which can only be read from the domain that set it. The actual cookies set by YouTube all include subdomains, but the one set by Cookie AutoDelete does not.

This causes the Python cookie file loader to fail, since it expects domains starting with a dot to match the subdomain flag (2nd flag in cookie file): https://github.com/python/cpython/blob/f46d8475749a0eadbc1f37079906a8e1ed5d56dc/Lib/http/cookiejar.py#L2050-L2051

I couldn't figure out, which exact format is represented here, but this commit fixes the browser plugin to respect the wishes of the underlying Python cookie jar.

Closes #42