### PR TITLE
Fixed missing channel button due to YT css change

### DIFF
--- a/extension/index.html
+++ b/extension/index.html
@@ -14,7 +14,7 @@
             <a href="#" id="ta-url" target="_blank">
                 <img src="/images/logo.png" alt="ta-logo">
             </a>
-            <span>v0.4.1</span>
+            <span>v0.4.2</span>
         </div>
         <hr>
         <form class="login-form">

--- a/extension/manifest-chrome.json
+++ b/extension/manifest-chrome.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "TubeArchivist Companion",
     "description": "Interact with your selfhosted TA server.",
-    "version": "0.4.1",
+    "version": "0.4.2",
     "icons": {
         "48": "/images/icon.png",
         "128": "/images/icon128.png"

--- a/extension/manifest-firefox.json
+++ b/extension/manifest-firefox.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "TubeArchivist Companion",
     "description": "Interact with your selfhosted TA server.",
-    "version": "0.4.1",
+    "version": "0.4.2",
     "icons": {
         "128": "/images/icon128.png"
     },

--- a/extension/script.js
+++ b/extension/script.js
@@ -107,7 +107,7 @@ function getBrowser() {
 
 function getChannelContainers() {
   const elements = document.querySelectorAll(
-    '.page-header-view-model-wiz__page-header-flexible-actions, #owner'
+     '.yt-page-header-view-model__page-header-flexible-actions, #owner'
   );
   const channelContainerNodes = [];
 


### PR DESCRIPTION
- The download button on the channel page was missing since a few days since Youtube changed the css of the page
- I changed the CSS selector to make the button visible again
- Bumped version proactively to 0.4.2