### PR TITLE
Correct typo in font URL which caused delays in opening the extension under certain circumstances

### DIFF
--- a/extension/index.html
+++ b/extension/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>TubeArchivist Companion</title>
-    <link rel="stylesheet" href="https://fonts.googleapi.com/css?family=Sen" type="text/css">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Sen" type="text/css">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>


### PR DESCRIPTION
This is a minor change that should, hopefully, fix an annoying to track down bug, #48.

The index.html file attempts to call "googleapi.com". The correct URL is "googleapis.com". The extension appears to fallback to a different font upon the failure, however on some VPNs, the incorrect URL will get stuck loading for ~10-20 seconds before falling back.

In the future, some additional error handling logic could be implemented to time the font request out after a few seconds. Theoretically, the extension would get stuck opening indefinitely if the font domain is ever unreachable but does not return an outright failure, although the browser would probably forcefully time it out after a little while. The font could also be bundled or cached locally so that it doesn't need to be fetched locally.

# Testing

I have been able to consistently reproduce #48 by using Windscribe VPN and Firefox on Windows 11. It is difficult to reproduce, as it seems to be caused by an old cached ip for that googleapi.com domain. Either way, this probably doesn't require extensive tests, as the typo domain is a (minor) issue either way. I did confirm that this resolves #48 for me by cloning the repo locally, changing the domain, and loading the extension in Firefox.

# Note
I didn't use any linter or IDE to make this change. I just used GitHub's built in code editor in the web GUI. I know last time this caused an issue with the linter, apologies if that happens again.