### PR TITLE
add delay to scheduleHideVideoButtons to ensure hover intent

### DIFF
--- a/extension/script.js
+++ b/extension/script.js
@@ -528,12 +528,28 @@ function showVideoButtons(e) {
 }
 
 function keepVideoButtonsVisible(e) {
-  let itemContainer = e.currentTarget.taItemContainer;
+  let button = e.currentTarget;
+  let itemContainer = button.taItemContainer;
   clearTimeout(itemContainer.taHideTimeout);
+
+  // reset the intention flag and start a timer
+  button.taIntentionalHover = false;
+  clearTimeout(button.taIntentTimeout);
+  button.taIntentTimeout = setTimeout(() => {
+    button.taIntentionalHover = true;
+  }, 200);
 }
 
 function scheduleHideVideoButtons(e) {
-  let itemContainer = e.currentTarget.taItemContainer || e.currentTarget;
+  let target = e.currentTarget;
+  let itemContainer = target.taItemContainer || target;
+
+  // if we are leaving a button, check if the hover was intentional
+  if (target.taItemContainer) {
+    clearTimeout(target.taIntentTimeout);
+    if (!target.taIntentionalHover) return;
+  }
+
   clearTimeout(itemContainer.taHideTimeout);
   itemContainer.taHideTimeout = setTimeout(() => {
     hideVideoButtons(itemContainer);


### PR DESCRIPTION
Firstly, AI disclosure: Code was penned by Gemini, reviewed, edited, and tested by me (who is admittedly an amateur).

A problem I was running into with the new video button overlay implementation was that if you entered the video title area from the right side (eg in order to view the video preview), you would often inadvertently sweep your mouse over the button. This would register as mouse on -> mouse off, and unintentionally trigger `scheduleHideVideoButtons`.

The solution I've implemented here is to add a delay which first tries to ensure hover intent:

- When `keepVideoButtonVisible` is triggered by a mouse over of the video button, `taIntentionalHover` is set to false and a 200ms timer is started
- When 200ms pass, this variable is set to true
- Separately, when `scheduleHideVideoButtons` is triggered by the mouse moving off of the button, a check has been added, the button will only hide if `taIntentionalHover` is set to true at that time
- If the cursor leaves the button in this 200ms window, the variable is currently set to false, and the button is not hidden
- If the cursor stays within the bounds of the button for 200ms, and then leaves, the variable is currently set to true, and the button is hidden

This allows the mouse cursor to quickly sweep over the button without inadvertently hiding it, but allows the user to mouse over and then off of the button if they intentionally want to hide it (eg if the button is obscuring an element below).

Current behavior (no hover intention check, button is hidden when quickly swept over):

https://github.com/user-attachments/assets/fce48a68-9f16-496f-a62e-d45a923aea7d

Video of testing new behavior (from Firefox, but also tested in Chrome):

https://github.com/user-attachments/assets/2c471a68-0f0b-48ba-a8cc-de5ab72e32e6