### PR TITLE
fix: limit YouTube mutation scans to relevant roots

### DIFF
--- a/extension/script.js
+++ b/extension/script.js
@@ -118,8 +118,18 @@ function getBrowser() {
   }
 }
 
-function getChannelContainers() {
-  const elements = document.querySelectorAll(channelContainerSelector);
+function getMatchingElements(root, selector) {
+  if (!root || typeof root.querySelectorAll !== 'function') return [];
+
+  const elements = Array.from(root.querySelectorAll(selector));
+  if (typeof root.matches === 'function' && root.matches(selector)) {
+    elements.unshift(root);
+  }
+  return elements;
+}
+
+function getChannelContainers(root = document) {
+  const elements = getMatchingElements(root, channelContainerSelector);
   const channelContainerNodes = [];
 
   elements.forEach(element => {
@@ -135,8 +145,8 @@ function isElementVisible(element) {
   return element.offsetWidth > 0 || element.offsetHeight > 0 || element.getClientRects().length > 0;
 }
 
-function ensureTALinks() {
-  let channelContainerNodes = getChannelContainers();
+function ensureTALinks(root = document) {
+  let channelContainerNodes = getChannelContainers(root);
 
   for (let channelContainer of channelContainerNodes) {
     channelContainer = adjustOwner(channelContainer);
@@ -146,9 +156,8 @@ function ensureTALinks() {
     channelContainer.hasTA = true;
   }
 
-  ensureVideoButtons();
+  ensureVideoButtons(root);
 }
-ensureTALinks = throttled(ensureTALinks, 700);
 
 function adjustOwner(channelContainer) {
   return channelContainer.querySelector('#buttons') || channelContainer;
@@ -460,8 +469,8 @@ function positionVideoButton(button) {
   button.style.right = `${containerRect.right - anchorRect.right + paddingRight + 4}px`;
 }
 
-function ensureVideoButtons() {
-  document.querySelectorAll(videoAnchorSelector).forEach(anchor => {
+function ensureVideoButtons(root = document) {
+  getMatchingElements(root, videoAnchorSelector).forEach(anchor => {
     if (!isElementVisible(anchor)) return;
     if (anchor.closest('.ta-button, .ta-channel-button')) return;
     if (!getVideoIdFromAnchor(anchor)) return;
@@ -678,15 +687,64 @@ function throttled(callback, time) {
   };
 }
 
+const matchingElementSelector = `${channelContainerSelector}, ${videoAnchorSelector}`;
+const pendingTARoots = new Set();
+
+function collapseTARoots(roots) {
+  const rootSet = new Set(roots);
+  if (rootSet.has(document)) return [document];
+
+  return roots.filter(root => {
+    let ancestor = root.parentElement;
+    while (ancestor) {
+      if (rootSet.has(ancestor)) return false;
+      ancestor = ancestor.parentElement;
+    }
+    return true;
+  });
+}
+
+const processPendingTARoots = throttled(() => {
+  const roots = collapseTARoots(Array.from(pendingTARoots));
+  pendingTARoots.clear();
+  roots.forEach(root => ensureTALinks(root));
+}, 700);
+
+function queueTALinks(roots) {
+  roots.forEach(root => {
+    if (root && typeof root.querySelectorAll === 'function') pendingTARoots.add(root);
+  });
+  if (pendingTARoots.size > 0) processPendingTARoots();
+}
+
+function getMutationRoots(list) {
+  const roots = new Set();
+
+  for (const item of list) {
+    if (item.type !== 'childList' || item.addedNodes.length === 0) continue;
+
+    for (const node of item.addedNodes) {
+      if (node.nodeType === 1) roots.add(node);
+    }
+
+    const target = item.target?.nodeType === 1 ? item.target : item.target?.parentElement;
+    const matchingAncestor = target?.closest?.(matchingElementSelector);
+    if (matchingAncestor) roots.add(matchingAncestor);
+  }
+
+  return Array.from(roots);
+}
+
 let observer = new MutationObserver(list => {
   const currentHref = document.location.href;
   if (currentHref !== oldHref) {
     cleanButtons();
     oldHref = currentHref;
+    queueTALinks([document]);
+    return;
   }
-  if (list.some(i => i.type === 'childList' && i.addedNodes.length > 0)) {
-    ensureTALinks();
-  }
+
+  queueTALinks(getMutationRoots(list));
 });
 
 observer.observe(document.body, { attributes: false, childList: true, subtree: true });

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1,0 +1,219 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+class FakeElement {
+  constructor(tagName = 'div', attributes = {}) {
+    this.tagName = tagName.toUpperCase();
+    this.nodeType = 1;
+    this.children = [];
+    this.parentElement = null;
+    this.attributes = { ...attributes };
+    this.dataset = {};
+    this.style = {};
+    this.offsetWidth = 100;
+    this.offsetHeight = 20;
+    this.directScans = 0;
+    this.classes = new Set();
+    this.classList = { add: value => this.classes.add(value) };
+  }
+
+  get isConnected() {
+    return this.parentElement !== null;
+  }
+
+  appendChild(child) {
+    child.parentElement = this;
+    this.children.push(child);
+    return child;
+  }
+
+  addEventListener() {}
+
+  contains(node) {
+    return this === node || this.children.some(child => child.contains(node));
+  }
+
+  getAttribute(name) {
+    return this.attributes[name] ?? null;
+  }
+
+  setAttribute(name, value) {
+    this.attributes[name] = String(value);
+    if (name.startsWith('data-')) {
+      this.dataset[name.slice(5)] = String(value);
+    }
+  }
+
+  matches(selector) {
+    return selector.split(',').some(part => {
+      const candidate = part.trim();
+      if (candidate === '.ta-button') return this.classes.has('ta-button');
+      if (candidate === '.ta-channel-button') return this.classes.has('ta-channel-button');
+      if (candidate === '#owner') return this.attributes.id === 'owner';
+      if (candidate.startsWith('a') && candidate.includes('[href]')) {
+        return this.tagName === 'A' && Boolean(this.attributes.href);
+      }
+      return false;
+    });
+  }
+
+  closest(selector) {
+    let current = this;
+    while (current) {
+      if (current.matches(selector)) return current;
+      current = current.parentElement;
+    }
+    return null;
+  }
+
+  findAll(selector) {
+    const matches = [];
+    for (const child of this.children) {
+      if (child.matches(selector)) matches.push(child);
+      matches.push(...child.findAll(selector));
+    }
+    return matches;
+  }
+
+  querySelectorAll(selector) {
+    this.directScans += 1;
+    return this.findAll(selector);
+  }
+
+  querySelector(selector) {
+    return this.findAll(selector)[0] ?? null;
+  }
+
+  getClientRects() {
+    return [{}];
+  }
+
+  getBoundingClientRect() {
+    return { top: 0, right: 100 };
+  }
+}
+
+function createHarness() {
+  const timers = [];
+  const observers = [];
+  const body = new FakeElement('body');
+  let documentScans = 0;
+  const location = {
+    href: 'https://www.youtube.com/watch?v=example',
+    origin: 'https://www.youtube.com',
+    pathname: '/watch',
+    search: '?v=example',
+  };
+  const document = {
+    body,
+    location,
+    createElement: tagName => new FakeElement(tagName),
+    querySelectorAll(selector) {
+      documentScans += 1;
+      return body.findAll(selector);
+    },
+  };
+
+  class MutationObserver {
+    constructor(callback) {
+      this.callback = callback;
+      observers.push(this);
+    }
+
+    observe() {}
+  }
+
+  const context = vm.createContext({
+    URL,
+    URLSearchParams,
+    chrome: { runtime: { sendMessage: () => Promise.resolve({}) } },
+    clearTimeout() {},
+    console: { log() {}, error() {} },
+    document,
+    getComputedStyle: () => ({
+      overflow: 'visible',
+      overflowX: 'visible',
+      overflowY: 'visible',
+      paddingRight: '0',
+      position: 'static',
+    }),
+    MutationObserver,
+    setTimeout(callback) {
+      timers.push(callback);
+      return timers.length;
+    },
+    window: { location },
+  });
+  const source = fs.readFileSync(path.join(__dirname, '..', 'extension', 'script.js'), 'utf8');
+  vm.runInContext(source, context);
+
+  return {
+    body,
+    documentScanCount: () => documentScans,
+    flushTimers() {
+      while (timers.length) timers.shift()();
+    },
+    observer: observers[0],
+  };
+}
+
+test('batches overlapping mutation roots and still inserts a button for an existing anchor', () => {
+  const harness = createHarness();
+  const scansAfterStartup = harness.documentScanCount();
+  const itemContainer = new FakeElement('div');
+  const anchor = new FakeElement('a', { href: '/watch?v=batched', id: 'video-title' });
+  const addedChild = new FakeElement('span');
+  anchor.appendChild(addedChild);
+  itemContainer.appendChild(anchor);
+  harness.body.appendChild(itemContainer);
+
+  harness.observer.callback([{ type: 'childList', target: anchor, addedNodes: [addedChild] }]);
+  harness.observer.callback([
+    { type: 'childList', target: harness.body, addedNodes: [itemContainer] },
+  ]);
+  harness.flushTimers();
+
+  assert.equal(
+    harness.documentScanCount(),
+    scansAfterStartup,
+    'mutation work must not rescan the document',
+  );
+  assert.equal(
+    itemContainer.directScans,
+    2,
+    'the outer root should be scanned once per selector group',
+  );
+  assert.equal(anchor.directScans, 0, 'the nested root should be collapsed into its ancestor');
+  assert.ok(
+    itemContainer.children.some(child => child.classes.has('ta-button')),
+    'video button should be inserted',
+  );
+});
+
+test('collapses deeply overlapping roots queued across multiple callbacks', () => {
+  const harness = createHarness();
+  const scansAfterStartup = harness.documentScanCount();
+  const roots = Array.from({ length: 100 }, () => new FakeElement('div'));
+  roots.slice(1).forEach((root, index) => roots[index].appendChild(root));
+  harness.body.appendChild(roots[0]);
+
+  for (let index = roots.length - 1; index >= 0; index -= 10) {
+    const addedNodes = roots.slice(Math.max(0, index - 9), index + 1).reverse();
+    harness.observer.callback([{ type: 'childList', target: harness.body, addedNodes }]);
+  }
+  harness.flushTimers();
+
+  assert.equal(
+    harness.documentScanCount(),
+    scansAfterStartup,
+    'mutation bursts must not rescan the document',
+  );
+  assert.equal(roots[0].directScans, 2, 'only the outermost queued root should be scanned');
+  assert.ok(
+    roots.slice(1).every(root => root.directScans === 0),
+    'nested roots should not be rescanned',
+  );
+});


### PR DESCRIPTION
## Summary

- batch YouTube mutation roots and scan only the outermost non-overlapping subtrees
- reconsider an existing channel container or video anchor when descendants are added inside it
- preserve full-document processing for initial load and SPA URL changes
- cover overlapping callbacks, existing-anchor button insertion, and a 100-root mutation burst

## Why

Issue #60 reports severe Firefox CPU and memory use on some YouTube videos. Mutation handling previously searched the full document for every processed batch. This change limits normal mutation work to affected roots while preserving existing matching ancestors that still need Tube Archivist buttons.

This is a scoped reduction in DOM scan work. It does not establish that selector scanning is the sole cause of #60 or claim a verified Firefox CPU or memory fix.

## Testing

- `OPENSSL_CONF=/dev/null node --test tests/script.test.js` — 2 tests passed in the clean network-off verifier
- `node --check extension/script.js` — passed in secret-free isolation
- `node --check tests/script.test.js` — passed in secret-free isolation
- `npm run lint` — passed with the repository ESLint configuration
- `prettier --check extension/script.js tests/script.test.js` — passed

The focused test fails on the upstream base because mutation work rescans the document. On this commit, two regression tests pass: an existing video anchor still receives its button after descendant changes, and 100 nested roots queued over multiple callbacks collapse to one outer-root scan without a new document scan.

## Limitations

- No end-to-end Firefox extension profile or CPU/memory comparison was run.
- The synthetic regression proves scan scope and button preservation, not resolution of every cause reported in #60.

---
AI assistance was used. I reviewed the resulting patch and its isolated verification evidence and accept responsibility for the submission.

<!-- northset-receipt:M-1042:start -->
### Verification

[Northset proof-of-pass receipt M-1042](https://northset-oss.github.io/verification-pilot/receipts/M-1042/)  
Contributor self-run; not maintainer verification.
<!-- northset-receipt:M-1042:end -->
